### PR TITLE
Set default login to dark theme. Fix background color for light theme

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -17,6 +17,14 @@
 @use "includes/icons/award-icons";
 @use "includes/icons/flag-icons";
 
+@include color-mode(dark) {
+  --bs-body-bg: #111; //sets dark body background dark
+}
+
+@include color-mode(light) {
+  --bs-body-bg: #efefef; //sets dark body background dark
+}
+
 h1,
 h2 {
   font-weight: 500;
@@ -36,11 +44,6 @@ input,
 select {
   padding: 0.6rem !important;
   height: auto !important;
-}
-
-body {
-  /* SUSE fog */
-  background-color: #efefef;
 }
 
 .navbar-nav .nav-link {

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-bs-theme="dark">
 <head>
   <title>{{ title or Configs.ctf_name }}</title>
   <meta charset="utf-8">


### PR DESCRIPTION
Sets the default theme style to "dark". Tweaks the body background color declarations to get appropriate backgrounds colors for both light and dark versions of the theme.